### PR TITLE
Updated kube config file to reflect changes in new IAM Authenticator Command

### DIFF
--- a/eks_switcher/files/config.jinja2
+++ b/eks_switcher/files/config.jinja2
@@ -17,7 +17,7 @@ users:
   user:
     exec:
       apiVersion: client.authentication.k8s.io/v1alpha1
-      command: heptio-authenticator-aws
+      command: aws-iam-authenticator
       args:
         - "token"
         - "-i"


### PR DESCRIPTION
The command has changed from `heptio-authenticator-aws` to `aws-iam-authenticator` 
https://github.com/kubernetes-sigs/aws-iam-authenticator.
https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
This may not be affecting you if you have not updated aws-iam-authenticator 